### PR TITLE
Loader Cache Decorators

### DIFF
--- a/EssentialApp.xctestplan
+++ b/EssentialApp.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "6A949939-9560-4122-B37A-41E83C6F7436",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:EssentialApp.xcodeproj",
+      "identifier" : "43EEC32E2E33B65F001A736F",
+      "name" : "EssentialApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:EssentialApp.xcodeproj",
+        "identifier" : "43EEC34A2E33D7B8001A736F",
+        "name" : "EssentialAppTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/CI_iOS.xcscheme
+++ b/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/CI_iOS.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+               BuildableName = "EssentialApp.app"
+               BlueprintName = "EssentialApp"
+               ReferencedContainer = "container:EssentialApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:../EssentialFeed/CI_iOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+            BuildableName = "EssentialApp.app"
+            BlueprintName = "EssentialApp"
+            ReferencedContainer = "container:EssentialApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+            BuildableName = "EssentialApp.app"
+            BlueprintName = "EssentialApp"
+            ReferencedContainer = "container:EssentialApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/EssentialApp.xcscheme
+++ b/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/EssentialApp.xcscheme
@@ -27,12 +27,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:../EssentialApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "43EEC34A2E33D7B8001A736F"

--- a/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/EssentialApp.xcscheme
+++ b/EssentialApp/EssentialApp.xcodeproj/xcshareddata/xcschemes/EssentialApp.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+               BuildableName = "EssentialApp.app"
+               BlueprintName = "EssentialApp"
+               ReferencedContainer = "container:EssentialApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "43EEC34A2E33D7B8001A736F"
+               BuildableName = "EssentialAppTests.xctest"
+               BlueprintName = "EssentialAppTests"
+               ReferencedContainer = "container:EssentialApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+            BuildableName = "EssentialApp.app"
+            BlueprintName = "EssentialApp"
+            ReferencedContainer = "container:EssentialApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "43EEC32E2E33B65F001A736F"
+            BuildableName = "EssentialApp.app"
+            BlueprintName = "EssentialApp"
+            ReferencedContainer = "container:EssentialApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/EssentialApp/EssentialApp.xcworkspace/contents.xcworkspacedata
+++ b/EssentialApp/EssentialApp.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:EssentialApp.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:../EssentialApp.xctestplan">
+   </FileRef>
 </Workspace>

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,30 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+    
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
+        decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        }
+    }
+    
+}

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -21,10 +21,16 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
         decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             })
         }
     }
     
+}
+
+private extension FeedImageDataCache {
+    func saveIgnoringResult(_ data: Data, for url: URL) {
+        save(data, for: url) { _ in }
+    }
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -20,9 +20,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
+                self?.cache.saveIgnoringResult(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringResult(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in }
+                return feed
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -23,7 +23,7 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
 }
 
-final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, loader) = makeSUT()
@@ -75,26 +75,6 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            exp.fulfill()
-        }
-        action()
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,13 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
-
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
     private let decoratee: FeedImageDataLoader

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,18 +8,29 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
+
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
     private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
     
-    init(decoratee: FeedImageDataLoader) {
+    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
-        decoratee.loadImageData(from: url, completion: completion)
+        decoratee.loadImageData(from: url) { [weak self] result in
+            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
+            completion(result)
+        }
     }
-    
     
 }
 
@@ -67,14 +78,38 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
         })
     }
     
+    func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let imageData = anyData()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: imageData)
+        
+        XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (FeedImageDataLoaderCacheDecorator, FeedImageDataLoaderSpy) {
+    private func makeSUT(cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> (FeedImageDataLoaderCacheDecorator, FeedImageDataLoaderSpy) {
         let loader = FeedImageDataLoaderSpy()
-        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
+    }
+    
+    private class CacheSpy: FeedImageDataCache {
+        enum Message: Equatable {
+            case save(data: Data, for: URL)
+        }
+        
+        private(set) var messages = [Message]()
+        
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+            messages.append(.save(data: data, for: url))
+        }
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -97,37 +97,4 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private class FeedImageDataLoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        
-        private(set) var cancelledURLs = [URL]()
-        
-        var loadedURLs: [URL] {
-            messages.map { $0.url }
-        }
-        
-        struct Task: FeedImageDataLoaderTask {
-            let callBack: () -> Void
-            func cancel() {
-                callBack()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-    }
-    
-    
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -27,8 +27,10 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
         decoratee.loadImageData(from: url) { [weak self] result in
-            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
-            completion(result)
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
         }
     }
     
@@ -88,6 +90,17 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
         loader.complete(with: imageData)
         
         XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
+    func test_loadImageData_doesNotCacheDataOnLoaderFailure() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: anyNSError())
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache image data on load error")
     }
     
     // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,133 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    
+    private let decoratee: FeedImageDataLoader
+    
+    init(decoratee: FeedImageDataLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
+        decoratee.loadImageData(from: url, completion: completion)
+    }
+    
+    
+}
+
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_init_doesNotLoadImageData() {
+        let (_, loader) = makeSUT()
+        
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+    }
+    
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+    
+    func test_cancelLoadImageData_cancelsLoaderTask() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        let task = sut.loadImageData(from: url) { _ in }
+        task.cancel()
+        
+        XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+    }
+    
+    func test_loadImageData_deliversDataOnLoaderSuccess() {
+        let imageData = anyData()
+        let (sut, loader) = makeSUT()
+        
+        expect(sut, toCompleteWith: .success(imageData), when: {
+            loader.complete(with: imageData)
+        })
+    }
+    
+    func test_loadImageData_deliversErrorOnLoaderFailure() {
+        let (sut, loader) = makeSUT()
+        
+        expect(sut, toCompleteWith: .failure(anyNSError()), when: {
+            loader.complete(with: anyNSError())
+        })
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (FeedImageDataLoaderCacheDecorator, FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
+    
+    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            exp.fulfill()
+        }
+        action()
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    private class FeedImageDataLoaderSpy: FeedImageDataLoader {
+        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+        
+        private(set) var cancelledURLs = [URL]()
+        
+        var loadedURLs: [URL] {
+            messages.map { $0.url }
+        }
+        
+        struct Task: FeedImageDataLoaderTask {
+            let callBack: () -> Void
+            func cancel() {
+                callBack()
+            }
+        }
+        
+        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+            messages.append((url, completion))
+            return Task { [weak self] in
+                self?.cancelledURLs.append(url)
+            }
+        }
+        
+        func complete(with data: Data, at index: Int = 0) {
+            messages[index].completion(.success(data))
+        }
+        
+        func complete(with error: Error, at index: Int = 0) {
+            messages[index].completion(.failure(error))
+        }
+    }
+    
+    
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -7,27 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-    
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) ->  FeedImageDataLoaderTask {
-        decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        }
-    }
-    
-}
+import EssentialApp
 
 final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
        let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -101,29 +101,6 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -93,9 +93,9 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -126,35 +126,4 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        private(set) var cancelledURLs = [URL]()
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callBack: () -> Void
-            func cancel() {
-                callBack()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[0].completion(.failure(error))
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[0].completion(.success(data))
-        }
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
+            completion(result.map { feed in
                 self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+                return feed
+            })
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias SaveResult = Result<Void, Error>
-    
-    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
-}
-
 final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,26 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
-                return feed
-            })
-        }
-    }
-}
-
+import EssentialApp
 
 final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,7 +25,9 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            self?.cache.save((try? result.get()) ?? []) { _ in }
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
             completion(result)
         }
     }
@@ -55,6 +57,15 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         sut.load { _ in }
         
         XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
+    
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache feed on load error")
     }
 
     // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,81 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 02/08/25.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+
+final class FeedLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .success(feed))
+    }
+
+    func test_load_deliversErrorOnLoaderFailure() {
+        let loader = LoaderStub(result: .failure(anyNSError()))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+
+        expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+
+    // MARK: - Helpers
+
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+            case (.failure, .failure):
+                break
+
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+    }
+
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+
+
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -61,8 +61,4 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
 
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,14 +25,14 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .success(feed))
     }
 
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = LoaderStub(result: .failure(anyNSError()))
+        let loader = FeedLoaderStub(result: .failure(anyNSError()))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -64,18 +64,5 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
     }
-
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
-    }
-
 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,17 +25,25 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
 
         expect(sut, toCompleteWith: .success(feed))
     }
 
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = FeedLoaderStub(result: .failure(anyNSError()))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
     }
 
+    // MARK: - Helpers
+    
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return sut
+    }
+    
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedCache {
+    typealias SaveResult = Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
+}
+
 final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
+    private let cache: FeedCache
 
-    init(decoratee: FeedLoader) {
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
 
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            self?.cache.save((try? result.get()) ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -25,7 +36,7 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let sut = makeSUT(loaderResult: .failure(anyNSError()))
+        let sut = makeSUT(loaderResult: .success(feed))
 
         expect(sut, toCompleteWith: .success(feed))
     }
@@ -35,15 +46,38 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
     }
+    
+    func test_load_cachesLoadedFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
 
     // MARK: - Helpers
     
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
+    }
+    
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+        
+        func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -21,7 +21,7 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 }
 
 
-final class FeedLoaderCacheDecoratorTests: XCTestCase {
+final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -36,29 +36,6 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
 
         expect(sut, toCompleteWith: .failure(anyNSError()))
-    }
-
-    // MARK: - Helpers
-
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-            case (.failure, .failure):
-                break
-
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: 1.0)
     }
 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -35,8 +35,8 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     // MARK: - Helpers
     
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -69,15 +69,4 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
     }
  
-    private class LoaderStub: FeedLoader {
-        let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -65,8 +65,4 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
- 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -42,27 +42,6 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,39 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+    
+    private(set) var cancelledURLs = [URL]()
+    
+    var loadedURLs: [URL] {
+        messages.map { $0.url }
+    }
+    
+    private struct Task: FeedImageDataLoaderTask {
+        let callBack: () -> Void
+        func cancel() { callBack() }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+    
+    func complete(with data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+    
+    func complete(with error: Error, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,20 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 02/08/25.
+//
+
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyData() -> Data {
     return Data("any data".utf8)
@@ -18,3 +19,8 @@ func anyURL() -> URL {
 func anyNSError() -> NSError {
     return NSError(domain: "any error", code: 0)
 }
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+}
+

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,34 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import XCTest
+import EssentialFeed
+
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            exp.fulfill()
+        }
+        action()
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,35 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by Prabhat Tiwari on 02/08/25.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+}

--- a/EssentialFeed/CI_iOS.xctestplan
+++ b/EssentialFeed/CI_iOS.xctestplan
@@ -20,7 +20,6 @@
       }
     },
     {
-      "enabled" : false,
       "target" : {
         "containerPath" : "container:EssentialApp.xcodeproj",
         "identifier" : "43EEC34A2E33D7B8001A736F",

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		436B185C2E30E99E000CC617 /* CacheFeedImageDataUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436B185B2E30E99E000CC617 /* CacheFeedImageDataUseCaseTests.swift */; };
 		437773EB2DE5654300C05D86 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437773EA2DE5654300C05D86 /* FeedStoreSpy.swift */; };
 		437B45E82DFEBAC100A28B72 /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 437B45DD2DFEBAC000A28B72 /* EssentialFeediOS.framework */; };
+		43ABB5C12E40F92500AD8FB5 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43ABB5C02E40F92500AD8FB5 /* FeedCache.swift */; };
 		43ABDC952E2A250D0049ACDB /* FeedPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43ABDC942E2A250D0049ACDB /* FeedPresenter.swift */; };
 		43ABDC962E2A25E00049ACDB /* Feed.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43ABDC8E2E2A1F8B0049ACDB /* Feed.strings */; };
 		43ABDC982E2A68FF0049ACDB /* FeedErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43ABDC972E2A68FF0049ACDB /* FeedErrorViewModel.swift */; };
@@ -161,6 +162,7 @@
 		437B45DD2DFEBAC000A28B72 /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		437B45E72DFEBAC100A28B72 /* EssentialFeediOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeediOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		43A45DCB2E0040930086E39C /* CI_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CI_iOS.xctestplan; sourceTree = "<group>"; };
+		43ABB5C02E40F92500AD8FB5 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		43ABDC8F2E2A1F8B0049ACDB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Feed.strings; sourceTree = "<group>"; };
 		43ABDC912E2A1F930049ACDB /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Feed.strings; sourceTree = "<group>"; };
 		43ABDC922E2A1F950049ACDB /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Feed.strings"; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				080EDF0B21B6DAE800813479 /* FeedImage.swift */,
 				080EDF0D21B6DCB600813479 /* FeedLoader.swift */,
 				43B5C6242E2CB157002C5B82 /* FeedImageDataLoader.swift */,
+				43ABB5C02E40F92500AD8FB5 /* FeedCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -764,6 +767,7 @@
 				43B5C65D2E2CCCD2002C5B82 /* FeedImageDataLoader.swift in Sources */,
 				43ABDC9A2E2A69170049ACDB /* FeedLoadingViewModel.swift in Sources */,
 				43B5C5632E2CAD09002C5B82 /* FeedImagePresenter.swift in Sources */,
+				43ABB5C12E40F92500AD8FB5 /* FeedCache.swift in Sources */,
 				433AF14F2DF596A000F06215 /* ManagedFeedImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		43F57C5A2DE31A8400789CC7 /* FeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F57C592DE31A8400789CC7 /* FeedStore.swift */; };
 		43F57C602DE376D000789CC7 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F57C5F2DE376D000789CC7 /* RemoteFeedItem.swift */; };
 		43F57C622DE3774400789CC7 /* LocalFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F57C612DE3774400789CC7 /* LocalFeedImage.swift */; };
+		43F8F4CC2E41FD5800C95815 /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F8F4CB2E41FD5800C95815 /* FeedImageDataCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -203,6 +204,7 @@
 		43F57C592DE31A8400789CC7 /* FeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStore.swift; sourceTree = "<group>"; };
 		43F57C5F2DE376D000789CC7 /* RemoteFeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedItem.swift; sourceTree = "<group>"; };
 		43F57C612DE3774400789CC7 /* LocalFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImage.swift; sourceTree = "<group>"; };
+		43F8F4CB2E41FD5800C95815 /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -337,6 +339,7 @@
 				080EDF0D21B6DCB600813479 /* FeedLoader.swift */,
 				43B5C6242E2CB157002C5B82 /* FeedImageDataLoader.swift */,
 				43ABB5C02E40F92500AD8FB5 /* FeedCache.swift */,
+				43F8F4CB2E41FD5800C95815 /* FeedImageDataCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -756,6 +759,7 @@
 				43ABDC982E2A68FF0049ACDB /* FeedErrorViewModel.swift in Sources */,
 				43ABDC9C2E2A692E0049ACDB /* FeedViewModel.swift in Sources */,
 				43F57C582DE319D400789CC7 /* LocalFeedLoader.swift in Sources */,
+				43F8F4CC2E41FD5800C95815 /* FeedImageDataCache.swift in Sources */,
 				43AE88532DCAFA5700090B14 /* HTTPClient.swift in Sources */,
 				436B18552E2FE165000CC617 /* FeedImageDataStore.swift in Sources */,
 				080EDF0C21B6DAE800813479 /* FeedImage.swift in Sources */,

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedImageDataLoader {
     
 }
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Swift.Result<Void, Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
     
     public enum SaveError: Error {
         case failed

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedLoader {
     }
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.SaveResult
     
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by Prabhat Tiwari on 04/08/25.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias SaveResult = Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
+}

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  EssentialFeed
+//
+//  Created by Prabhat Tiwari on 05/08/25.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added `[*]LoaderCacheDecorators` responsible for decorating (intercepting) `load` operations and injecting the `save` side-effect on successful load results.

We can now use the decorators to compose the `RemoteFeedLoader.loadwith` the `LocalFeedLoader.save` operations in a simple, clean, extendable, modular, and testable way.